### PR TITLE
Bug fixes

### DIFF
--- a/html/Asset/Search/Bulk.html
+++ b/html/Asset/Search/Bulk.html
@@ -6,7 +6,7 @@
 <& /Elements/ListActions, actions => \@results &>
 
 <form method="post" action="<% RT->Config->Get('WebPath') %>/Asset/Search/Bulk.html" enctype="multipart/form-data" name="BulkUpdate" id="BulkUpdate">
-% foreach my $var ( @{$search{'PassArguments'}} )  {
+% foreach my $var ( @{$search{'PassArguments'} || []} )  {
 <input type="hidden" class="hidden" name="<% $var %>" value="<% $ARGS{$var} || '' %>" />
 % }
 % foreach my $var (qw(Query Format OrderBy Order Rows Page Token)) {
@@ -108,6 +108,29 @@ my $assets = RT::Assets->new($session{CurrentUser});
 my %search;
 if ( $ARGS{Query} ) {
     $assets->FromSQL($ARGS{Query});
+
+    unless ( defined $Rows ) {
+        $Rows = $RowsPerPage;
+        $ARGS{Rows} = $RowsPerPage;
+    }
+
+    if ( $OrderBy =~ /\|/ ) {
+
+        # Multiple Sorts
+        my @OrderBy = split /\|/, $OrderBy;
+        my @Order   = split /\|/, $Order;
+        $assets->OrderByCols(
+            map { { FIELD => $OrderBy[$_], ORDER => $Order[$_] } }
+                ( 0 .. $#OrderBy ) );
+    }
+    else {
+        $assets->OrderBy( FIELD => $OrderBy, ORDER => $Order );
+    }
+
+    $assets->RowsPerPage($Rows) if ($Rows);
+    $assets->GotoPage( $Page - 1 );     # SB uses page 0 as the first page
+
+    %search = map { $_ => $ARGS{$_} } qw(Query OrderBy Order Rows Page);
 }
 else {
     %search = ProcessAssetsSearchArguments(
@@ -158,5 +181,10 @@ elsif ( $ARGS{Update} ) {
 }
 </%INIT>
 <%ARGS>
+$Page => 1
+$Rows => undef
+$RowsPerPage => undef
+$Order => 'ASC'
+$OrderBy => 'id'
 @UpdateAsset => ()
 </%ARGS>

--- a/html/Callbacks/AssetSQL/Elements/Tabs/Privileged
+++ b/html/Callbacks/AssetSQL/Elements/Tabs/Privileged
@@ -101,7 +101,7 @@ elsif ($Path =~ m{^/Asset/Search/}) {
     $page->child( advanced => title => loc('Advanced'), path => '/Asset/Search/Edit.html' . $args, sort_order => 2 );
     if ($has_query) {
         # these overwrite the core Asset menu items
-        $page->child( results => title => loc('Show Results'), path => '/Asset/Search/Results.html' . $args, sort_order => 3 );
+        $page->child( search => title => loc('Show Results'), path => '/Asset/Search/Results.html' . $args, sort_order => 3 );
         $page->child('bulk',
             title => loc('Bulk Update'),
             path => '/Asset/Search/Bulk.html' . $args,

--- a/patches/rt-4.4.0.patch
+++ b/patches/rt-4.4.0.patch
@@ -377,3 +377,22 @@ index 853ba86..8d5aaa0 100644
      jQuery("#assets-create").click(function(ev){
          ev.preventDefault();
          jQuery.get(
+--- a/share/html/Helpers/BuildFormatString	2019-08-27 15:12:44.000000000 -0700
++++ b/share/html/Helpers/BuildFormatString	2019-09-16 14:56:31.000000000 -0700
+@@ -46,8 +46,15 @@
+ %#
+ %# END BPS TAGGED BLOCK }}}
+ <%init>
++my $FormatStringBuilderElement = '/Search/Elements/BuildFormatString';
++if ( RT::Interface::Web::RequestENV('HTTP_REFERER') ) {
++    my $referer = URI->new(RT::Interface::Web::RequestENV('HTTP_REFERER'));
++    if ($referer->path =~ m{^/Asset/Search/Build\.html$}) {
++        $FormatStringBuilderElement = '/Asset/Search/Elements/BuildFormatString';
++    }
++}
+ my ( $Format, $AvailableColumns, $CurrentFormat ) = $m->comp(
+-    '/Search/Elements/BuildFormatString',
++    $FormatStringBuilderElement,
+     %ARGS
+ );
+ $r->content_type('application/json; charset=utf-8');

--- a/patches/rt-4.4.1.patch
+++ b/patches/rt-4.4.1.patch
@@ -377,3 +377,22 @@ index 853ba86..8d5aaa0 100644
      jQuery("#assets-create").click(function(ev){
          ev.preventDefault();
          jQuery.get(
+--- a/share/html/Helpers/BuildFormatString	2019-08-27 15:12:44.000000000 -0700
++++ b/share/html/Helpers/BuildFormatString	2019-09-16 14:56:31.000000000 -0700
+@@ -46,8 +46,15 @@
+ %#
+ %# END BPS TAGGED BLOCK }}}
+ <%init>
++my $FormatStringBuilderElement = '/Search/Elements/BuildFormatString';
++if ( RT::Interface::Web::RequestENV('HTTP_REFERER') ) {
++    my $referer = URI->new(RT::Interface::Web::RequestENV('HTTP_REFERER'));
++    if ($referer->path =~ m{^/Asset/Search/Build\.html$}) {
++        $FormatStringBuilderElement = '/Asset/Search/Elements/BuildFormatString';
++    }
++}
+ my ( $Format, $AvailableColumns, $CurrentFormat ) = $m->comp(
+-    '/Search/Elements/BuildFormatString',
++    $FormatStringBuilderElement,
+     %ARGS
+ );
+ $r->content_type('application/json; charset=utf-8');

--- a/patches/rt-4.4.2-later.patch
+++ b/patches/rt-4.4.2-later.patch
@@ -71,3 +71,22 @@ index 53ad702..5be90d6 100644
      $ProcessedSearchArg->{TotalFound} = $count;
  }
  </%init>
+--- a/share/html/Helpers/BuildFormatString	2019-08-27 15:12:44.000000000 -0700
++++ b/share/html/Helpers/BuildFormatString	2019-09-16 14:56:31.000000000 -0700
+@@ -46,8 +46,15 @@
+ %#
+ %# END BPS TAGGED BLOCK }}}
+ <%init>
++my $FormatStringBuilderElement = '/Search/Elements/BuildFormatString';
++if ( RT::Interface::Web::RequestENV('HTTP_REFERER') ) {
++    my $referer = URI->new(RT::Interface::Web::RequestENV('HTTP_REFERER'));
++    if ($referer->path =~ m{^/Asset/Search/Build\.html$}) {
++        $FormatStringBuilderElement = '/Asset/Search/Elements/BuildFormatString';
++    }
++}
+ my ( $Format, $AvailableColumns, $CurrentFormat ) = $m->comp(
+-    '/Search/Elements/BuildFormatString',
++    $FormatStringBuilderElement,
+     %ARGS
+ );
+ $r->content_type('application/json; charset=utf-8');


### PR DESCRIPTION
Fixes three moderately annoying bugs in this extension.

First, make the bulk updater obey the sorting and paging settings of your search.
Second, there is an existing asset "Show Results" menu item (shows up on Asset/Search/Bulk.html) (menu key 'search'), override that one rather than inserting a second one (menu key 'results').
Third, the "Display Columns" section of the asset search builder makes ajax calls to /Helper/BuildFormatString, which loads the ticket-specific version of BuildFormatString. Patch it to load the asset version when referred to by Asset/Search/Build.html.
